### PR TITLE
set project version to 0.0.0 which will be used for publishing packag…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.9.0",
+  "version": "0.0.0",
   "scripts": {
     "generate-api-clients": "sh ./hack/generate-api-clients.sh",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sdk-test"
-version = "0.9.4"
+version = "0.0.0"
 authors = [
     { name = "Mirko Dzaja", email = "mirkodzaja0@gmail.com" },
 ]


### PR DESCRIPTION
…es to test pypi while official realeases will use version from tag which triggered GH action for publishing